### PR TITLE
Add files separately to prevent errors when none provided.

### DIFF
--- a/Mailin.php
+++ b/Mailin.php
@@ -863,18 +863,24 @@ class Mailin
 
     $request = $this->domain;
 	
-	$atcmnt = $this->getAttachments();
-
     // we'll append the Bcc, Cc, replyto, to, files to the url endpoint (GET)
     // so that we can still post array.
     $request.= "?" .
-	substr($this->_arrayToUrlPart($this->getBccs(), "bcc"), 1) .
-	$this->_arrayToUrlPart($this->getCcs(), "cc") .
-	$this->_arrayToUrlPartTwo($this->getReplyto(), "replyto") .
-	$this->_arrayToUrlPart($this->getTos(), "to") .
-	$this->_arrayToUrlPartThree($atcmnt, "files");
+        substr($this->_arrayToUrlPart($this->getBccs(), "bcc"), 1) .
+        $this->_arrayToUrlPart($this->getCcs(), "cc") .
+        $this->_arrayToUrlPartTwo($this->getReplyto(), "replyto") .
+        $this->_arrayToUrlPart($this->getTos(), "to");
+  
+    // Append the files seperately to prevent array error when there isn't any
+    $atcmnt = $this->getAttachments();
+    if($atcmnt)
+    {
+        $request = $request .  
+        $this->_arrayToUrlPartThree($atcmnt, "files");
+    }
+
 	  
-	$session = curl_init($request);
+    $session = curl_init($request);
     curl_setopt ($session, CURLOPT_POST, true);
     curl_setopt ($session, CURLOPT_POSTFIELDS, $data);
 


### PR DESCRIPTION
I have an issue with PHP FAM 7.4 in an alpine image when the files array is empty and have needed to attach the files array only when there are some to attach else the error prevents the XHR from returning cleanly.

Small fix applied to send.